### PR TITLE
Update `Croniter` to Version `1.3.7`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ source:
   {{ hash_type }}: {{ hash }}
 
 build:
-  preserve_egg_dir: True
   number: 0
   skip: True  # [py<34]
   script: python -m pip install --no-deps --ignore-installed .
@@ -32,6 +31,7 @@ requirements:
 
 test:
   imports:
+    - croniter
     - croniter.croniter
   requires:
     - pip
@@ -42,6 +42,8 @@ about:
   home: https://github.com/kiorky/croniter
   license: MIT
   license_family: MIT
+  license_url: https://github.com/kiorky/croniter/blob/master/docs/LICENSE
+  license_file: docs/LICENSE
   summary: 'croniter provides iteration for datetime object with cron like format'
   description: "croniter provides iteration for the datetime object with a cron like format."
   dev_url: https://github.com/kiorky/croniter

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://files.pythonhosted.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
   {{ hash_type }}: {{hash}}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "croniter" %}
-{% set version = "1.0.15" %}
+{% set version = "1.3.7" %}
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash = "a70dfc9d52de9fc1a886128b9148c89dd9e76b67d55f46516ca94d2d73d58219" %}
+{% set hash = "72ef78d0f8337eb35393b8893ebfbfbeb340f2d2ae47e0d2d78130e34b0dd8b9" %}
 
 package:
   name: {{ name }}
@@ -14,9 +14,9 @@ source:
   {{ hash_type }}: {{ hash }}
 
 build:
-  noarch: python
   preserve_egg_dir: True
   number: 0
+  skip: True  # [py<34]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -43,6 +43,7 @@ about:
   license: MIT
   license_family: MIT
   summary: 'croniter provides iteration for datetime object with cron like format'
+  description: "croniter provides iteration for the datetime object with a cron like format."
   dev_url: https://github.com/kiorky/croniter
   doc_url: https://github.com/kiorky/croniter#readme
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  {{ hash_type }}: {{ hash }}
+  url: https://files.pythonhosted.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{hash}}
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,11 +19,13 @@ build:
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
+  host:
+    - python
+    - wheel
+    - setuptools
   build:
     - python
     - pip
-    - wheel
-    - setuptools
 
   run:
     - python
@@ -48,6 +50,7 @@ about:
   description: "croniter provides iteration for the datetime object with a cron like format."
   dev_url: https://github.com/kiorky/croniter
   doc_url: https://github.com/kiorky/croniter#readme
+  doc_source_url: https://github.com/kiorky/croniter#readme
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,11 +21,9 @@ build:
 requirements:
   host:
     - python
+    - pip
     - wheel
     - setuptools
-  build:
-    - python
-    - pip
 
   run:
     - python


### PR DESCRIPTION
Update `Croniter` To Version `1.3.7`
1. - [X] Check the upstream
    https://github.com/kiorky/croniter/tree/1.3.7
2. - [X] Check the pinnings
3. - [X] Check the changelogs
    https://github.com/kiorky/croniter/blob/1.3.7/docs/CHANGES.rst
4. - [X] Additional research
    https://github.com/conda-forge/croniter-feedstock/issues

    There is only one open issue and it is only related to formatting of the feedstock in condaforge. 

5. - [X] Verify the `dev_url`
    https://github.com/kiorky/croniter
6. - [X] Verify the `doc_url`
    https://github.com/kiorky/croniter#readme
7. - [X] License is `spdx` compliant
    MIT
8. - [X] License family is present
    MIT
9. - [X] Verify that the `build_number` is correct
10. - [X] Verify if the package needs `setuptools`
    setuptools
11. - [X] Verify if the package needs `wheel`
    wheel
12. - [X] `pip` in the test section
    pip
13. - [X] Veriy the test section
14. - [X] Verify if the package is `architecture specific` or `Noarch`
15. - [X] Verify that private modules are not mentioned on the recipe For example: (_private_module)

Results:
-


Based on the research findings and the results we can conclude
that it is safe to update `croniter` to version `1.3.7`

