### PR TITLE
Croniter update v3.0.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   run:
     - python
     - python-dateutil
+    - pytz
 
 test:
   imports:
@@ -31,7 +32,6 @@ test:
     - croniter.croniter
   requires:
     - pip
-    - pytz
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ about:
   home: https://github.com/kiorky/croniter
   license: MIT
   license_family: MIT
-  license_url: https://github.com/kiorky/croniter/blob/master/docs/LICENSE
+  license_url: https://github.com/kiorky/croniter/blob/master/LICENSE
   summary: 'croniter provides iteration for datetime object with cron like format'
   description: "croniter provides iteration for the datetime object with a cron like format."
   dev_url: https://github.com/kiorky/croniter

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - python
     - python-dateutil
-    - pytz
+    - pytz >2021.1
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,17 @@
 {% set name = "croniter" %}
-{% set version = "1.3.7" %}
-{% set bundle = "tar.gz" %}
-{% set hash_type = "sha256" %}
-{% set hash = "72ef78d0f8337eb35393b8893ebfbfbeb340f2d2ae47e0d2d78130e34b0dd8b9" %}
+{% set version = "3.0.3" %}
 
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  {{ hash_type }}: {{hash}}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 34117ec1741f10a7bd0ec3ad7d8f0eb8fa457a2feb9be32e6a2250e158957668
 
 build:
   number: 0
-  skip: True  # [py<34]
+  skip: True  # [py<38]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -35,6 +31,7 @@ test:
     - croniter.croniter
   requires:
     - pip
+    - pytz
   commands:
     - pip check
 
@@ -43,7 +40,7 @@ about:
   license: MIT
   license_family: MIT
   license_url: https://github.com/kiorky/croniter/blob/master/docs/LICENSE
-  license_file: docs/LICENSE
+  license_file: LICENSE
   summary: 'croniter provides iteration for datetime object with cron like format'
   description: "croniter provides iteration for the datetime object with a cron like format."
   dev_url: https://github.com/kiorky/croniter

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<38]
-  script: python -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir --no-build-isolation -vv
 
 requirements:
   host:
@@ -40,12 +40,10 @@ about:
   license: MIT
   license_family: MIT
   license_url: https://github.com/kiorky/croniter/blob/master/docs/LICENSE
-  license_file: LICENSE
   summary: 'croniter provides iteration for datetime object with cron like format'
   description: "croniter provides iteration for the datetime object with a cron like format."
   dev_url: https://github.com/kiorky/croniter
   doc_url: https://github.com/kiorky/croniter#readme
-  doc_source_url: https://github.com/kiorky/croniter#readme
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
## ☆Croniter 3.0.3 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5253)
[Upstream](https://github.com/kiorky/croniter)
# Changes
- Updated version number and `sha256`
- Skip to `python` versions less than 3.8
- Updated formatting to our more modern `meta.yaml` format