### PR TITLE
croniter 6.2.2 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "croniter" %}
-{% set version = "6.0.0" %}
+{% set version = "6.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,18 +7,24 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 37c504b313956114a983ece2c2b07790b1f1094fe9d81cc94739214748255577
+  sha256: ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab
 
 build:
   number: 0
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
-    - wheel
-    - setuptools
+    - hatchling >=1.29.0
+    - packaging >=26.0
+    - pathspec >=1.0.4
+    # upstream requred pluggy==1.6.0, but we have 1.5.0 at the moment
+    # TODO: re-pin this once pluggy 1.6.0 available
+    - pluggy >=1.5.0
+    - trove-classifiers >=2026.1.14.14
   run:
     - python
     - python-dateutil
@@ -44,7 +50,7 @@ test:
     - pytest >=8.3.3
 
 about:
-  home: https://github.com/kiorky/croniter
+  home: https://github.com/pallets-eco/croniter
   license: MIT
   license_family: MIT
   license_url: https://github.com/kiorky/croniter/blob/master/LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,15 +21,14 @@ requirements:
     - hatchling >=1.29.0
     - packaging >=26.0
     - pathspec >=1.0.4
-    # upstream requred pluggy==1.6.0, but we have 1.5.0 at the moment
-    # TODO: re-pin this once pluggy 1.6.0 available
+    # Temporary downstream deviation from upstream build-system pin (pluggy==1.6.0)
+    # because pluggy 1.6.0 is not yet available here.
+    # TODO: Re-pin exactly when available.
     - pluggy >=1.5.0
     - trove-classifiers >=2026.1.14.14
   run:
     - python
     - python-dateutil
-    - pytz >2021.1
-
 
 #   >       time.tzset()
 #   E       AttributeError: module 'time' has no attribute 'tzset'
@@ -48,16 +47,17 @@ test:
   requires:
     - pip
     - pytest >=8.3.3
+    - pytz >2021.1
 
 about:
   home: https://github.com/pallets-eco/croniter
   license: MIT
   license_family: MIT
-  license_url: https://github.com/kiorky/croniter/blob/master/LICENSE
-  summary: 'croniter provides iteration for datetime object with cron like format'
-  description: "croniter provides iteration for the datetime object with a cron like format."
-  dev_url: https://github.com/kiorky/croniter
-  doc_url: https://github.com/kiorky/croniter#readme
+  license_file: LICENSE
+  summary: croniter provides iteration for datetime object with cron like format
+  description: croniter provides iteration for the datetime object with a cron like format
+  dev_url: https://github.com/pallets-eco/croniter
+  doc_url: https://github.com/pallets-eco/croniter#readme
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
croniter 6.2.2 

**Destination channel:** Defaults

### Links

- [PKG-13170]
- dev_url:        https://github.com/kiorky/croniter/tree/6.2.2
- conda_forge:    https://github.com/conda-forge/croniter-feedstock
- pypi:           https://pypi.org/project/croniter/6.2.2
- pypi inspector: https://inspector.pypi.io/project/croniter/6.2.2

### Explanation of changes:

- new version number


[PKG-13170]: https://anaconda.atlassian.net/browse/PKG-13170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ